### PR TITLE
smg_pgp_association: fix compilation with gcc-5.2

### DIFF
--- a/src/smg_pgp_association.cc
+++ b/src/smg_pgp_association.cc
@@ -28,6 +28,7 @@
 
 #include <errno.h>
 #include <cstring>
+#include <cstdlib>
 #include <arpa/inet.h>
 
 #include "smg_pgp_association.h"


### PR DESCRIPTION
This patch fixes the following error:

```
smg_pgp_association.cc: In member function 'virtual bool SmgPgpAssociation::fromText(std::__cxx11::string&)':
smg_pgp_association.cc:201:68: error: 'strtol' was not declared in this scope
        else if (0 == (iLen = (int) strtol((*tIter).c_str(), NULL, 10))
```
